### PR TITLE
Properly handle numbers, escape codes, and nulls

### DIFF
--- a/json2csv.c
+++ b/json2csv.c
@@ -21,7 +21,7 @@ uses json-c fork at http://github.com/jehiah/json-c
 #define SUCCESS 0
 #define FAILURE 1
 
-#define JSON_GET_STR(json_obj, field) (json_object_get_string(json_object_object_get(json_obj, field)))
+#define JSON_GET_STR(json_obj, field) (json_object_to_json_string(json_object_object_get(json_obj, field)))
 #define JSON_GET_INT(json_obj, field) (json_object_get_int(json_object_object_get(json_obj, field)))
 #define JSON_FREE(json_obj) (json_object_put(json_obj))
 #define JSON_DEBUG 0
@@ -75,9 +75,9 @@ void process_line(char *source, FILE *output)
     }
     for (i=0; i < num_output_keys; i++) {
         if (i == 0) {
-            fprintf(output, "\"%s\"", JSON_GET_STR(json_obj, output_keys[i]));
+            fprintf(output, "%s", strcmp(JSON_GET_STR(json_obj, output_keys[i]), "null") == 0 ? "" : JSON_GET_STR(json_obj, output_keys[i]) );
         } else {
-            fprintf(output, ",\"%s\"", JSON_GET_STR(json_obj, output_keys[i]));
+            fprintf(output, ",%s", strcmp(JSON_GET_STR(json_obj, output_keys[i]), "null") == 0 ? "" : JSON_GET_STR(json_obj, output_keys[i]) );
         }
     }
     fprintf(output,"\n");

--- a/test/test1.expected
+++ b/test/test1.expected
@@ -1,2 +1,4 @@
-"1"
-"(null)"
+1
+
+"\"quote test\""
+"regular quote"

--- a/test/test1.json
+++ b/test/test1.json
@@ -1,2 +1,4 @@
 {"a": 1, "b": "asdf\n"}
 {"a" : null}
+{"a": "\"quote test\""}
+{"a": "regular quote"}


### PR DESCRIPTION
In this pull request, I use the already escaped JSON strings, and just account for the special case for nulls. As an added benefit, numbers also come across correctly now. Closes #2
