### PR TITLE
Add flag for tab delimited output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: go
+go:
+  - 1.5.3
+  - 1.6
+sudo: false
 install:
   - go get github.com/bmizerany/assert
 notifications:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ type LineReader interface {
 
 var (
 	inputFile   = flag.String("i", "", "/path/to/input.json (optional; default is stdin)")
-	outputFile  = flag.String("o", "", "/path/to/output.json (optional; default is stdout)")
+	outputFile  = flag.String("o", "", "/path/to/output.csv (optional; default is stdout)")
 	outputDelim = flag.String("d", ",", "delimiter used for output values")
 	verbose     = flag.Bool("v", false, "verbose output (to stderr)")
 	showVersion = flag.Bool("version", false, "print version string")

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	inputFile   = flag.String("i", "", "/path/to/input.json (optional; default is stdin)")
 	outputFile  = flag.String("o", "", "/path/to/output.csv (optional; default is stdout)")
 	outputDelim = flag.String("d", ",", "delimiter used for output values")
+	outputTab   = flag.Bool("t", false, "tab delimited output (overrides -d)")
 	verbose     = flag.Bool("v", false, "verbose output (to stderr)")
 	showVersion = flag.Bool("version", false, "print version string")
 	printHeader = flag.Bool("p", false, "prints header to output")
@@ -65,6 +66,9 @@ func main() {
 	}
 
 	delim, _ := utf8.DecodeRuneInString(*outputDelim)
+	if *outputTab {
+		delim = '\t'
+	}
 	writer.Comma = delim
 
 	json2csv(reader, writer, keys, *printHeader)

--- a/main_test.go
+++ b/main_test.go
@@ -22,7 +22,7 @@ func TestGetTopic(t *testing.T) {
 	json2csv(reader, writer, []string{"a", "c"}, false)
 
 	output := buf.String()
-	assert.Equal(t, output, "1,\"\"\n\"\",\"\"\n")
+	assert.Equal(t, output, "1,\n,\n")
 }
 
 func TestGetLargeInt(t *testing.T) {


### PR DESCRIPTION
Added a flag for tab delimited output, as depending on shell, escaped string may need a prefix (ex. -d $'\t').

New flag also bypasses need for extra string to rune conversion.
